### PR TITLE
Update hex packaged files

### DIFF
--- a/src/ezlib.app.src
+++ b/src/ezlib.app.src
@@ -29,7 +29,7 @@
   {mod,          {ezlib_app,[]}},
 
   %% hex.pm packaging:
-  {files, ["src/", "c_src/ezlib_drv.c", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt"]},
+  {files, ["src/", "c_src/ezlib_drv.c", "configure", "rebar.config", "rebar.config.script", "vars.config.in", "README.md", "LICENSE.txt"]},
   {licenses, ["Apache 2.0"]},
   {links, [{"Github", "https://github.com/processone/ezlib"}]}]}.
 


### PR DESCRIPTION
'configure' and 'vars.config.in' are required to build as ejabberd
dependencies with rebar3