### PR TITLE
PR_erlang-p1-ezlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - ppc64le
+  - amd64
 language: erlang
 
 os: linux
@@ -6,6 +9,7 @@ dist: xenial
 
 before_install:
   - pip install --user cpp-coveralls coveralls-merge
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 install:
   - ./configure --enable-gcov
@@ -23,3 +27,12 @@ otp_release:
   - 18.1
   - 22.3
   - 23.0
+# Disable otp_release 17.1, 17.5, 18.1 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 17.1
+  - arch: ppc64le
+    otp_release: 17.5
+  - arch: ppc64le
+    otp_release: 18.1


### PR DESCRIPTION
Following changes are made in this commit to Travis.yml
Excluding Jobs for otp_releases:17.1/17.5/18.1 as these are not supported on Ubuntu16.04 with arch: ppc64le
And added a new line under "before_install" to make the build run for otp_releases:22.3/23.0 which are supported on Ubuntu16.04 with arch: ppc64le.

Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Excluding Jobs for otp_releases:17.1/17.5/18.1 as these are not supported on Ubuntu16.04 with arch: ppc64le
Please refer to the link: https://docs.travis-ci.com/user/languages/erlang/#otprelease-versions

The build is successful for rest all(including arch: ppc64le/amd64). Please refer to Travis link: https://travis-ci.com/github/santosh653/ezlib

And added a new line under "before_install" to make the build run for otp_releases:22.3/23.0 which are supported on Ubuntu16.04 with arch: ppc64le.